### PR TITLE
Update php requirement to 5.6+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "name": "twicpics/url",
     "readme": "README.md",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.6.0"
     },
     "require-dev": {
         "php": ">=7.1.0",


### PR DESCRIPTION
The code currently uses short array syntax `[]`, and unpacking operators `...`,
which require PHP 5.4 and 5.6 respectively.